### PR TITLE
NibUICollectionReusableView 코드 추가

### DIFF
--- a/Sources/ImgBaseUI/NibUICollectionReusableView.swift
+++ b/Sources/ImgBaseUI/NibUICollectionReusableView.swift
@@ -1,0 +1,53 @@
+//
+//  NibUICollectionReusableView.swift
+//  imgbase-kit
+//
+//  Created by Hyuncheol Jeon on 27/12/2022.
+//  Copyright © 2022 ImgBase, Inc. All rights reserved.
+//
+
+import UIKit
+
+open class NibUICollectionReusableView: UICollectionReusableView {
+    @IBOutlet public weak var containerView: UIView!
+    open var nibName: String? {
+        return nil
+    }
+
+    open var bundle: Bundle? {
+        return nil
+    }
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    open func commonInit() {
+        if let nibName: String = nibName {
+            if let bundle = bundle {
+                containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
+            } else {
+                Bundle.main.loadNibNamed(nibName, owner: self, options: nil)
+            }
+            addSubview(containerView)
+            containerView.frame = bounds
+            containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        }
+    }
+
+    private func viewFromNibForClass(nibName: String, withBundle bundle: Bundle) -> UIView {
+        let nibView: UIView = (UINib.init(nibName: nibName, bundle: bundle).instantiate(withOwner: self, options: nil).first as? UIView)!
+        return nibView
+    }
+
+    public func viewFromNibForClass(nibName: String) -> UIView {
+        let nibView: UIView = (UINib.init(nibName: nibName, bundle: nil).instantiate(withOwner: self, options: nil).first as? UIView)!
+        return nibView
+    }
+}

--- a/Sources/ImgBaseUI/NibUICollectionReusableView.swift
+++ b/Sources/ImgBaseUI/NibUICollectionReusableView.swift
@@ -8,10 +8,10 @@
 
 import UIKit
 
-open class NibUICollectionReusableView: UICollectionReusableView {
+open class NibUICollectionReusableView: UICollectionReusableView, NibUIBase {
     @IBOutlet public weak var containerView: UIView!
-    open var nibName: String? {
-        return nil
+    open var nibName: String {
+        return String(describing: Self.self)
     }
 
     open var bundle: Bundle? {
@@ -29,25 +29,10 @@ open class NibUICollectionReusableView: UICollectionReusableView {
     }
 
     open func commonInit() {
-        if let nibName: String = nibName {
-            if let bundle = bundle {
-                containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
-            } else {
-                Bundle.main.loadNibNamed(nibName, owner: self, options: nil)
-            }
-            addSubview(containerView)
-            containerView.frame = bounds
-            containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        }
-    }
+        containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
 
-    private func viewFromNibForClass(nibName: String, withBundle bundle: Bundle) -> UIView {
-        let nibView: UIView = (UINib.init(nibName: nibName, bundle: bundle).instantiate(withOwner: self, options: nil).first as? UIView)!
-        return nibView
-    }
-
-    public func viewFromNibForClass(nibName: String) -> UIView {
-        let nibView: UIView = (UINib.init(nibName: nibName, bundle: nil).instantiate(withOwner: self, options: nil).first as? UIView)!
-        return nibView
+        addSubview(containerView)
+        containerView.frame = bounds
+        containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     }
 }


### PR DESCRIPTION
- 기존 라이브러리 코드 중 `NibCollectionReusableView` 누락되어서 추가 필요
- 네이밍을 최신 규격에 맞춰 `NibUICollectionReusableView` 적용하여 기존 코드 구조로 추가함