### PR TITLE
상속 후 Xib가 없는 경우 대응하도록 NibName 코드 수정

### DIFF
--- a/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUIButton/CustomNibUIButton.swift
+++ b/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUIButton/CustomNibUIButton.swift
@@ -12,6 +12,10 @@ class CustomNibUIButton: NibUIButton {
     @IBOutlet weak var innerView: UIView!
     @IBOutlet weak var label: UILabel!
 
+    override var nibName: String? {
+        return "CustomNibUIButton"
+    }
+
     func setColor(isWhite: Bool) {
         innerView.backgroundColor = isWhite ? .white : .darkGray
         label.textColor = isWhite ? .darkGray : .white

--- a/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUICollectionViewCell/CustomNibUICollectionViewCell.swift
+++ b/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUICollectionViewCell/CustomNibUICollectionViewCell.swift
@@ -15,4 +15,6 @@ class CustomNibUICollectionViewCell: NibUICollectionViewCell {
     override var nibName: String? {
         return "CustomNibUICollectionViewCell"
     }
+
+    static let reuseIdentifier = "CustomNibUICollectionViewCellReuseIdentifier"
 }

--- a/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUICollectionViewCell/CustomNibUICollectionViewCell.swift
+++ b/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUICollectionViewCell/CustomNibUICollectionViewCell.swift
@@ -11,4 +11,8 @@ import ImgBaseUI
 class CustomNibUICollectionViewCell: NibUICollectionViewCell {
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var label: UILabel!
+
+    override var nibName: String? {
+        return "CustomNibUICollectionViewCell"
+    }
 }

--- a/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUICollectionViewCell/NibUICollectionReusableView/CustomNibUICollectionReusableView.swift
+++ b/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUICollectionViewCell/NibUICollectionReusableView/CustomNibUICollectionReusableView.swift
@@ -11,4 +11,8 @@ import ImgBaseUI
 class CustomNibUICollectionReusableView: NibUICollectionReusableView {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var subTitleLabel: UILabel!
+
+    override var nibName: String? {
+        return "CustomNibUICollectionReusableView"
+    }
 }

--- a/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUICollectionViewCell/NibUICollectionReusableView/CustomNibUICollectionReusableView.swift
+++ b/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUICollectionViewCell/NibUICollectionReusableView/CustomNibUICollectionReusableView.swift
@@ -15,4 +15,6 @@ class CustomNibUICollectionReusableView: NibUICollectionReusableView {
     override var nibName: String? {
         return "CustomNibUICollectionReusableView"
     }
+
+    static let reuseIdentifier = "CustomNibUICollectionReusableViewReuseIdentifier"
 }

--- a/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUITableViewCell/CustomNibUITableViewCell.swift
+++ b/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUITableViewCell/CustomNibUITableViewCell.swift
@@ -16,4 +16,6 @@ class CustomNibUITableViewCell: NibUITableViewCell {
     override var nibName: String? {
         return "CustomNibUITableViewCell"
     }
+
+    static let reuseIdentifier = "CustomNibUITableViewCellReuseIdentifier"
 }

--- a/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUITableViewCell/CustomNibUITableViewCell.swift
+++ b/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUITableViewCell/CustomNibUITableViewCell.swift
@@ -12,4 +12,8 @@ class CustomNibUITableViewCell: NibUITableViewCell {
     @IBOutlet weak var myImageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var subTitleLabel: UILabel!
+
+    override var nibName: String? {
+        return "CustomNibUITableViewCell"
+    }
 }

--- a/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUIView/CustomNibUIView.swift
+++ b/Examples/ImgBaseUI_Example/ImgBaseUI_Example/NibUIView/CustomNibUIView.swift
@@ -12,6 +12,10 @@ import ImgBaseUI
 class CustomNibUIView: NibUIView {
     @IBOutlet weak var label: UILabel!
 
+    override var nibName: String? {
+        return "CustomNibUIView"
+    }
+
     override func commonInit() {
         super.commonInit()
 

--- a/Sources/ImgBaseUI/NibUIBase.swift
+++ b/Sources/ImgBaseUI/NibUIBase.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol NibUIBase: AnyObject {
     var containerView: UIView! { get set }
-    var nibName: String { get }
+    var nibName: String? { get }
     var bundle: Bundle? { get }
     
     func commonInit()

--- a/Sources/ImgBaseUI/NibUIButton.swift
+++ b/Sources/ImgBaseUI/NibUIButton.swift
@@ -11,8 +11,8 @@ import UIKit
 open class NibUIButton: UIButton, NibUIBase {
     @IBOutlet public weak var containerView: UIView!
     
-    open var nibName: String {
-        return String(describing: Self.self)
+    open var nibName: String? {
+        return nil
     }
     
     open var bundle: Bundle? {
@@ -30,11 +30,13 @@ open class NibUIButton: UIButton, NibUIBase {
     }
     
     open func commonInit() {
-        containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
-
-        addSubview(containerView)
-        containerView.frame = bounds
-        containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        containerView.isUserInteractionEnabled = false
+        if let nibName {
+            containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
+            
+            addSubview(containerView)
+            containerView.frame = bounds
+            containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            containerView.isUserInteractionEnabled = false
+        }
     }
 }

--- a/Sources/ImgBaseUI/NibUICollectionReusableView.swift
+++ b/Sources/ImgBaseUI/NibUICollectionReusableView.swift
@@ -19,10 +19,6 @@ open class NibUICollectionReusableView: UICollectionReusableView, NibUIBase {
         return nil
     }
 
-    open class var reuseIdentifier: String {
-        return String(describing: Self.self) + "ReuseIdentifier"
-    }
-
     override public init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()

--- a/Sources/ImgBaseUI/NibUICollectionReusableView.swift
+++ b/Sources/ImgBaseUI/NibUICollectionReusableView.swift
@@ -11,8 +11,8 @@ import UIKit
 open class NibUICollectionReusableView: UICollectionReusableView, NibUIBase {
     @IBOutlet public weak var containerView: UIView!
 
-    open var nibName: String {
-        return String(describing: Self.self)
+    open var nibName: String? {
+        return nil
     }
 
     open var bundle: Bundle? {
@@ -34,10 +34,12 @@ open class NibUICollectionReusableView: UICollectionReusableView, NibUIBase {
     }
 
     open func commonInit() {
-        containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
-
-        addSubview(containerView)
-        containerView.frame = bounds
-        containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        if let nibName {
+            containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
+            
+            addSubview(containerView)
+            containerView.frame = bounds
+            containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        }
     }
 }

--- a/Sources/ImgBaseUI/NibUICollectionViewCell.swift
+++ b/Sources/ImgBaseUI/NibUICollectionViewCell.swift
@@ -18,10 +18,6 @@ open class NibUICollectionViewCell: UICollectionViewCell, NibUIBase {
     open var bundle: Bundle? {
         return nil
     }
-    
-    open class var reuseIdentifier: String {
-        return String(describing: Self.self) + "ReuseIdentifier"
-    }
 
     public override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Sources/ImgBaseUI/NibUICollectionViewCell.swift
+++ b/Sources/ImgBaseUI/NibUICollectionViewCell.swift
@@ -11,8 +11,8 @@ import UIKit
 open class NibUICollectionViewCell: UICollectionViewCell, NibUIBase {
     @IBOutlet public weak var containerView: UIView!
     
-    open var nibName: String {
-        return String(describing: Self.self)
+    open var nibName: String? {
+        return nil
     }
     
     open var bundle: Bundle? {
@@ -34,10 +34,12 @@ open class NibUICollectionViewCell: UICollectionViewCell, NibUIBase {
     }
     
     open func commonInit() {
-        containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
-
-        contentView.addSubview(containerView)
-        containerView.frame = bounds
-        containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        if let nibName {
+            containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
+            
+            contentView.addSubview(containerView)
+            containerView.frame = bounds
+            containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        }
     }
 }

--- a/Sources/ImgBaseUI/NibUITableViewCell.swift
+++ b/Sources/ImgBaseUI/NibUITableViewCell.swift
@@ -11,8 +11,8 @@ import UIKit
 open class NibUITableViewCell: UITableViewCell, NibUIBase {
     @IBOutlet public weak var containerView: UIView!
     
-    open var nibName: String {
-        return String(describing: Self.self)
+    open var nibName: String? {
+        return nil
     }
     
     open var bundle: Bundle? {
@@ -34,10 +34,12 @@ open class NibUITableViewCell: UITableViewCell, NibUIBase {
     }
     
     open func commonInit() {
-        containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
-
-        contentView.addSubview(containerView)
-        containerView.frame = bounds
-        containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        if let nibName {
+            containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
+            
+            contentView.addSubview(containerView)
+            containerView.frame = bounds
+            containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        }
     }
 }

--- a/Sources/ImgBaseUI/NibUITableViewCell.swift
+++ b/Sources/ImgBaseUI/NibUITableViewCell.swift
@@ -18,10 +18,6 @@ open class NibUITableViewCell: UITableViewCell, NibUIBase {
     open var bundle: Bundle? {
         return nil
     }
-    
-    open class var reuseIdentifier: String {
-        return String(describing: Self.self) + "ReuseIdentifier"
-    }
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)

--- a/Sources/ImgBaseUI/NibUIView.swift
+++ b/Sources/ImgBaseUI/NibUIView.swift
@@ -11,8 +11,8 @@ import UIKit
 open class NibUIView: UIView, NibUIBase {
     @IBOutlet public weak var containerView: UIView!
     
-    open var nibName: String {
-        return String(describing: Self.self)
+    open var nibName: String? {
+        return nil
     }
     
     open var bundle: Bundle? {
@@ -30,10 +30,12 @@ open class NibUIView: UIView, NibUIBase {
     }
     
     open func commonInit() {
-        containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
+        if let nibName {
+            containerView = viewFromNibForClass(nibName: nibName, withBundle: bundle)
 
-        addSubview(containerView)
-        containerView.frame = bounds
-        containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            addSubview(containerView)
+            containerView.frame = bounds
+            containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        }
     }
 }


### PR DESCRIPTION
- NibUIBase NibName 타입을 Optional로 변경
- 기본 구현으로 `String(describing: Self.self)`를 반환할 경우 상속에 대응하지 못하므로, 기존 override 코드처럼 파일마다 `"파일명"` String 값을 반환해주어야함.

close #15 

