### PR TITLE
fix: show() 직후 즉시 dismiss() 실행시 progressView가 사라지지 않고 화면이 먹통되는 버그 수정

### DIFF
--- a/Sources/IMProgressHUD/IMProgressHUD.swift
+++ b/Sources/IMProgressHUD/IMProgressHUD.swift
@@ -104,12 +104,13 @@ public class IMProgressHUD {
   }
 
   public static func dismiss() {
-    guard contentViewAnimationAssistant.isPresenting else { return }
-
     contentViewAnimationAssistant.addDisappearObserver(self, selector: #selector(dismissProgressView))
     contentViewAnimationAssistant.dismissWithAnimation()
-
     setIsUserInteractionEnabled(true)
+    progressView.constraints.forEach { constraint in
+      constraint.isActive = false
+    }
+    progressView.removeFromSuperview()
   }
 
   private static func timeOutDismiss() {


### PR DESCRIPTION
### 변경내용
`contentViewAnimationAssistant.showWithAnimation()` 메소드 내에서 비동기 애니메이션 로직 실행 완료 후 completion handler 에서 `contentViewAnimationAssistant.isPresenting = true` 로 변경하는 로직인데
`show()` 직후 `dismiss()`를 즉시 실행하게되면 아직 `isPresenting = false` 상태이기에 guard 구문에서 걸려 `dismiss()` 로직이 실행되지 않았습니다.

### 관련 아사나 이슈
https://app.asana.com/1/24804123230557/project/1208406157697912/task/1210139300933036?focus=true